### PR TITLE
Bump start-sdk to 1.5.1 (10.11.8:4)

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -6,7 +6,7 @@
     "": {
       "name": "jellyfin-startos",
       "dependencies": {
-        "@start9labs/start-sdk": "1.3.3",
+        "@start9labs/start-sdk": "1.5.1",
         "filebrowser-startos": "github:Start9Labs/filebrowser-startos#master",
         "nextcloud-startos": "github:Start9Labs/nextcloud-startos#master"
       },
@@ -51,9 +51,9 @@
       }
     },
     "node_modules/@nodable/entities": {
-      "version": "1.1.0",
-      "resolved": "https://registry.npmjs.org/@nodable/entities/-/entities-1.1.0.tgz",
-      "integrity": "sha512-bidpxmTBP0pOsxULw6XlxzQpTgrAGLDHGBK/JuWhPDL6ZV0GZ/PmN9CA9do6e+A9lYI6qx6ikJUtJYRxup141g==",
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/@nodable/entities/-/entities-2.1.0.tgz",
+      "integrity": "sha512-nyT7T3nbMyBI/lvr6L5TyWbFJAI9FTgVRakNoBqCD+PmID8DzFrrNdLLtHMwMszOtqZa8PAOV24ZqDnQrhQINA==",
       "funding": [
         {
           "type": "github",
@@ -63,9 +63,9 @@
       "license": "MIT"
     },
     "node_modules/@start9labs/start-sdk": {
-      "version": "1.3.3",
-      "resolved": "https://registry.npmjs.org/@start9labs/start-sdk/-/start-sdk-1.3.3.tgz",
-      "integrity": "sha512-aL9ilSj6CyP2+tSooxPZFqWXP1/1dMgYljcu1s2ECoPv6CTmSBqwrBw9SdsQp7PYmnU4rsSZQteWogkDOf93YQ==",
+      "version": "1.5.1",
+      "resolved": "https://registry.npmjs.org/@start9labs/start-sdk/-/start-sdk-1.5.1.tgz",
+      "integrity": "sha512-iztLiOCtHuTfUCd2JOWio4OvBk5qFGa0NI+G+ZB/dQ1sWtunYEnzqMcF6N/Ss4L6+7bBOMAMU4VuhyxeZoHyIw==",
       "license": "MIT",
       "dependencies": {
         "@iarna/toml": "^3.0.0",
@@ -73,12 +73,12 @@
         "@noble/hashes": "^1.8.0",
         "@types/ini": "^4.1.1",
         "deep-equality-data-structures": "^2.0.0",
-        "fast-xml-parser": "~5.6.0",
+        "fast-xml-parser": "~5.7.0",
         "ini": "^5.0.0",
         "isomorphic-fetch": "^3.0.0",
         "mime": "^4.1.0",
         "yaml": "^2.8.3",
-        "zod": "^4.3.6",
+        "zod": "4.3.6",
         "zod-deep-partial": "^1.2.0"
       }
     },
@@ -89,9 +89,9 @@
       "license": "MIT"
     },
     "node_modules/@types/node": {
-      "version": "20.19.37",
-      "resolved": "https://registry.npmjs.org/@types/node/-/node-20.19.37.tgz",
-      "integrity": "sha512-8kzdPJ3FsNsVIurqBs7oodNnCEVbni9yUEkaHbgptDACOPW04jimGagZ51E6+lXUwJjgnBw+hyko/lkFWCldqw==",
+      "version": "20.19.41",
+      "resolved": "https://registry.npmjs.org/@types/node/-/node-20.19.41.tgz",
+      "integrity": "sha512-ECymXOukMnOoVkC2bb1Vc/w/836DXncOg5m8Xj1RH7xSHZJWNYY6Zh7EH477vcnD5egKNNfy2RpNOmuChhFPgQ==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
@@ -118,9 +118,9 @@
       }
     },
     "node_modules/fast-xml-builder": {
-      "version": "1.1.5",
-      "resolved": "https://registry.npmjs.org/fast-xml-builder/-/fast-xml-builder-1.1.5.tgz",
-      "integrity": "sha512-4TJn/8FKLeslLAH3dnohXqE3QSoxkhvaMzepOIZytwJXZO69Bfz0HBdDHzOTOon6G59Zrk6VQ2bEiv1t61rfkA==",
+      "version": "1.2.0",
+      "resolved": "https://registry.npmjs.org/fast-xml-builder/-/fast-xml-builder-1.2.0.tgz",
+      "integrity": "sha512-00aAWieqff+ZJhsXA4g1g7M8k+7AYoMUUHF+/zFb5U6Uv/P0Vl4QZo84/IcufzYalLuEj9928bXN9PbbFzMF0Q==",
       "funding": [
         {
           "type": "github",
@@ -129,13 +129,14 @@
       ],
       "license": "MIT",
       "dependencies": {
-        "path-expression-matcher": "^1.1.3"
+        "path-expression-matcher": "^1.5.0",
+        "xml-naming": "^0.1.0"
       }
     },
     "node_modules/fast-xml-parser": {
-      "version": "5.6.0",
-      "resolved": "https://registry.npmjs.org/fast-xml-parser/-/fast-xml-parser-5.6.0.tgz",
-      "integrity": "sha512-5G+uaEBbOm9M4dgMOV3K/rBzfUNGqGqoUTaYJM3hBwM8t71w07gxLQZoTsjkY8FtfjabqgQHEkeIySBDYeBmJw==",
+      "version": "5.7.3",
+      "resolved": "https://registry.npmjs.org/fast-xml-parser/-/fast-xml-parser-5.7.3.tgz",
+      "integrity": "sha512-C0AaNuC+mscy6vrAQKAc/rMq+zAPHodfHGZu4sGVehvAQt/JLG1O5zEcYcXSY5zSqr4YVgxsB+pHXTq0i7eDlg==",
       "funding": [
         {
           "type": "github",
@@ -144,8 +145,8 @@
       ],
       "license": "MIT",
       "dependencies": {
-        "@nodable/entities": "^1.1.0",
-        "fast-xml-builder": "^1.1.4",
+        "@nodable/entities": "^2.1.0",
+        "fast-xml-builder": "^1.1.7",
         "path-expression-matcher": "^1.5.0",
         "strnum": "^2.2.3"
       },
@@ -154,29 +155,9 @@
       }
     },
     "node_modules/filebrowser-startos": {
-      "resolved": "git+ssh://git@github.com/Start9Labs/filebrowser-startos.git#51b94d0708c45a0d7a3e75b00936bd8a4f75f070",
+      "resolved": "git+ssh://git@github.com/Start9Labs/filebrowser-startos.git#2e3b8680affe59b76507e10fb670ba73360bf630",
       "dependencies": {
-        "@start9labs/start-sdk": "1.3.2"
-      }
-    },
-    "node_modules/filebrowser-startos/node_modules/@start9labs/start-sdk": {
-      "version": "1.3.2",
-      "resolved": "https://registry.npmjs.org/@start9labs/start-sdk/-/start-sdk-1.3.2.tgz",
-      "integrity": "sha512-Iw26tSjN+2yKYul8VabrV9VtpbHnEes4FCCxhGrmdFzjP/wc+K4DLqN+cLgqwtVebVB0mJVhhh63nbRil1pqWg==",
-      "license": "MIT",
-      "dependencies": {
-        "@iarna/toml": "^3.0.0",
-        "@noble/curves": "^1.9.7",
-        "@noble/hashes": "^1.8.0",
-        "@types/ini": "^4.1.1",
-        "deep-equality-data-structures": "^2.0.0",
-        "fast-xml-parser": "~5.6.0",
-        "ini": "^5.0.0",
-        "isomorphic-fetch": "^3.0.0",
-        "mime": "^4.1.0",
-        "yaml": "^2.8.3",
-        "zod": "^4.3.6",
-        "zod-deep-partial": "^1.2.0"
+        "@start9labs/start-sdk": "1.5.1"
       }
     },
     "node_modules/ini": {
@@ -214,29 +195,9 @@
       }
     },
     "node_modules/nextcloud-startos": {
-      "resolved": "git+ssh://git@github.com/Start9Labs/nextcloud-startos.git#49930735d362a2408380f3eb094d4323be3327e1",
+      "resolved": "git+ssh://git@github.com/Start9Labs/nextcloud-startos.git#2ebe5cb385716cd7b478a43cd9d261b3349ade00",
       "dependencies": {
-        "@start9labs/start-sdk": "1.3.2"
-      }
-    },
-    "node_modules/nextcloud-startos/node_modules/@start9labs/start-sdk": {
-      "version": "1.3.2",
-      "resolved": "https://registry.npmjs.org/@start9labs/start-sdk/-/start-sdk-1.3.2.tgz",
-      "integrity": "sha512-Iw26tSjN+2yKYul8VabrV9VtpbHnEes4FCCxhGrmdFzjP/wc+K4DLqN+cLgqwtVebVB0mJVhhh63nbRil1pqWg==",
-      "license": "MIT",
-      "dependencies": {
-        "@iarna/toml": "^3.0.0",
-        "@noble/curves": "^1.9.7",
-        "@noble/hashes": "^1.8.0",
-        "@types/ini": "^4.1.1",
-        "deep-equality-data-structures": "^2.0.0",
-        "fast-xml-parser": "~5.6.0",
-        "ini": "^5.0.0",
-        "isomorphic-fetch": "^3.0.0",
-        "mime": "^4.1.0",
-        "yaml": "^2.8.3",
-        "zod": "^4.3.6",
-        "zod-deep-partial": "^1.2.0"
+        "@start9labs/start-sdk": "1.5.1"
       }
     },
     "node_modules/node-fetch": {
@@ -284,9 +245,9 @@
       }
     },
     "node_modules/prettier": {
-      "version": "3.8.1",
-      "resolved": "https://registry.npmjs.org/prettier/-/prettier-3.8.1.tgz",
-      "integrity": "sha512-UOnG6LftzbdaHZcKoPFtOcCKztrQ57WkHDeRD9t/PTQtmT0NHSeWWepj6pS0z/N7+08BHFDQVUrfmfMRcZwbMg==",
+      "version": "3.8.3",
+      "resolved": "https://registry.npmjs.org/prettier/-/prettier-3.8.3.tgz",
+      "integrity": "sha512-7igPTM53cGHMW8xWuVTydi2KO233VFiTNyF5hLJqpilHfmn8C8gPf+PS7dUT64YcXFbiMGZxS9pCSxL/Dxm/Jw==",
       "dev": true,
       "license": "MIT",
       "bin": {
@@ -300,9 +261,9 @@
       }
     },
     "node_modules/strnum": {
-      "version": "2.2.3",
-      "resolved": "https://registry.npmjs.org/strnum/-/strnum-2.2.3.tgz",
-      "integrity": "sha512-oKx6RUCuHfT3oyVjtnrmn19H1SiCqgJSg+54XqURKp5aCMbrXrhLjRN9TjuwMjiYstZ0MzDrHqkGZ5dFTKd+zg==",
+      "version": "2.3.0",
+      "resolved": "https://registry.npmjs.org/strnum/-/strnum-2.3.0.tgz",
+      "integrity": "sha512-ums3KNd42PGyx5xaoVTO1mjU1bH3NpY4vsrVlnv9PNGqQj8wd7rJ6nEypLrJ7z5vxK5RP0yMLo6J/Gsm62DI5Q==",
       "funding": [
         {
           "type": "github",
@@ -360,10 +321,25 @@
         "webidl-conversions": "^3.0.0"
       }
     },
+    "node_modules/xml-naming": {
+      "version": "0.1.0",
+      "resolved": "https://registry.npmjs.org/xml-naming/-/xml-naming-0.1.0.tgz",
+      "integrity": "sha512-k8KO9hrMyNk6tUWqUfkTEZbezRRpONVOzUTnc97VnCvyj6Tf9lyUR9EDAIeiVLv56jsMcoXEwjW8Kv5yPY52lw==",
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/NaturalIntelligence"
+        }
+      ],
+      "license": "MIT",
+      "engines": {
+        "node": ">=16.0.0"
+      }
+    },
     "node_modules/yaml": {
-      "version": "2.8.3",
-      "resolved": "https://registry.npmjs.org/yaml/-/yaml-2.8.3.tgz",
-      "integrity": "sha512-AvbaCLOO2Otw/lW5bmh9d/WEdcDFdQp2Z2ZUH3pX9U2ihyUY0nvLv7J6TrWowklRGPYbB/IuIMfYgxaCPg5Bpg==",
+      "version": "2.9.0",
+      "resolved": "https://registry.npmjs.org/yaml/-/yaml-2.9.0.tgz",
+      "integrity": "sha512-2AvhNX3mb8zd6Zy7INTtSpl1F15HW6Wnqj0srWlkKLcpYl/gMIMJiyuGq2KeI2YFxUPjdlB+3Lc10seMLtL4cA==",
       "license": "ISC",
       "bin": {
         "yaml": "bin.mjs"
@@ -380,7 +356,6 @@
       "resolved": "https://registry.npmjs.org/zod/-/zod-4.3.6.tgz",
       "integrity": "sha512-rftlrkhHZOcjDwkGlnUtZZkvaPHCsDATp4pGpuOOMDaTdDDXF91wuVDJoWoPsKX/3YPQ5fHuF3STjcYyKr+Qhg==",
       "license": "MIT",
-      "peer": true,
       "funding": {
         "url": "https://github.com/sponsors/colinhacks"
       }

--- a/package.json
+++ b/package.json
@@ -6,7 +6,7 @@
     "check": "tsc --noEmit"
   },
   "dependencies": {
-    "@start9labs/start-sdk": "1.3.3",
+    "@start9labs/start-sdk": "1.5.1",
     "filebrowser-startos": "github:Start9Labs/filebrowser-startos#master",
     "nextcloud-startos": "github:Start9Labs/nextcloud-startos#master"
   },

--- a/startos/versions/index.ts
+++ b/startos/versions/index.ts
@@ -1,7 +1,7 @@
 import { VersionGraph } from '@start9labs/start-sdk'
-import { v_10_11_8_3 } from './v10.11.8.3'
+import { v_10_11_8_4 } from './v10.11.8.4'
 
 export const versionGraph = VersionGraph.of({
-  current: v_10_11_8_3,
+  current: v_10_11_8_4,
   other: [],
 })

--- a/startos/versions/v10.11.8.4.ts
+++ b/startos/versions/v10.11.8.4.ts
@@ -3,19 +3,24 @@ import { readFile, rm } from 'fs/promises'
 import { configJson, defaultPlugins } from '../fileModels/config.json'
 import { store, type StoreType } from '../fileModels/store.json'
 
-export const v_10_11_8_3 = VersionInfo.of({
-  version: '10.11.8:3',
+export const v_10_11_8_4 = VersionInfo.of({
+  version: '10.11.8:4',
   releaseNotes: {
-    en_US:
-      'Fix server crash on CPUs without SSE4.1 (pre-2008 Intel, pre-Bulldozer AMD, early Atom): swap libe_sqlite3.so for the build shipped in Jellyfin 10.10.7. See jellyfin/jellyfin#15148.',
-    es_ES:
-      'Corrige el cierre del servidor en CPU sin SSE4.1 (Intel anterior a 2008, AMD anterior a Bulldozer, Atom temprano): se sustituye libe_sqlite3.so por la versión incluida en Jellyfin 10.10.7. Véase jellyfin/jellyfin#15148.',
-    de_DE:
-      'Behebt den Serverabsturz auf CPUs ohne SSE4.1 (Intel vor 2008, AMD vor Bulldozer, frühe Atom): libe_sqlite3.so wird durch die Version aus Jellyfin 10.10.7 ersetzt. Siehe jellyfin/jellyfin#15148.',
-    pl_PL:
-      'Naprawia awarię serwera na procesorach bez SSE4.1 (Intel sprzed 2008, AMD sprzed Bulldozera, wczesne Atom): biblioteka libe_sqlite3.so zostaje zastąpiona wersją z Jellyfin 10.10.7. Zobacz jellyfin/jellyfin#15148.',
-    fr_FR:
-      "Corrige le plantage du serveur sur les CPU sans SSE4.1 (Intel pré-2008, AMD pré-Bulldozer, premiers Atom) : libe_sqlite3.so est remplacée par la version livrée dans Jellyfin 10.10.7. Voir jellyfin/jellyfin#15148.",
+    en_US: `**Internal**
+
+- Bump start-sdk to 1.5.1.`,
+    es_ES: `**Interno**
+
+- Actualización de start-sdk a 1.5.1.`,
+    de_DE: `**Intern**
+
+- start-sdk auf 1.5.1 aktualisiert.`,
+    pl_PL: `**Wewnętrzne**
+
+- Aktualizacja start-sdk do 1.5.1.`,
+    fr_FR: `**Interne**
+
+- Mise à jour de start-sdk vers 1.5.1.`,
   },
   migrations: {
     up: async ({ effects }) => {


### PR DESCRIPTION
## Summary

- Bump `@start9labs/start-sdk` from 1.3.3 to 1.5.1.
- Bump StartOS revision: `10.11.8:3` → `10.11.8:4`.

No upstream Jellyfin bump — 10.11.8 is still latest.

## SDK 1.3.3 → 1.5.1 impact on this package

Reviewed the changelog for breaking changes that could affect this package:

- **1.4.0 (breaking):** `FileHelper.yaml` transformers overload reordered. **N/A** — this package only uses `FileHelper.json` and `FileHelper.xml`.
- **1.4.1:** `zod` pinned to `4.3.6` to keep `.catch()` semantics for `.merge({})` seed pattern. We rely on this pattern (`networkXml.merge(effects, {})`, `configJson.merge`, `store.write`) — pin is inherited transitively, no action needed.
- **1.4.2:** `VersionGraph.uninit` now throws on contradictory targets — no effect; our graph is single-current with `other: []`.
- **1.1.0 removals:** `trigger.changeOnFirstSuccess`, `trigger.successFailure`, `trigger.lastStatus` — not used; primary daemon uses default trigger.
- Other 1.2.x–1.5.x additions (`footnote`, `Value.triState`, `sdk.notification.create`, `FileHelper.yaml` options, `Backups.withPgDump`, etc.) are additive and not adopted here.

## Test plan

- [x] `make` builds both x86_64 and aarch64 s9pks green