### PR TITLE
Bump start-sdk to 1.5.2 (10.11.8:5)

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -6,7 +6,7 @@
     "": {
       "name": "jellyfin-startos",
       "dependencies": {
-        "@start9labs/start-sdk": "1.5.1",
+        "@start9labs/start-sdk": "1.5.2",
         "filebrowser-startos": "github:Start9Labs/filebrowser-startos#next",
         "nextcloud-startos": "github:Start9Labs/nextcloud-startos#next"
       },
@@ -63,9 +63,9 @@
       "license": "MIT"
     },
     "node_modules/@start9labs/start-sdk": {
-      "version": "1.5.1",
-      "resolved": "https://registry.npmjs.org/@start9labs/start-sdk/-/start-sdk-1.5.1.tgz",
-      "integrity": "sha512-iztLiOCtHuTfUCd2JOWio4OvBk5qFGa0NI+G+ZB/dQ1sWtunYEnzqMcF6N/Ss4L6+7bBOMAMU4VuhyxeZoHyIw==",
+      "version": "1.5.2",
+      "resolved": "https://registry.npmjs.org/@start9labs/start-sdk/-/start-sdk-1.5.2.tgz",
+      "integrity": "sha512-3L4OKuH9kUtuH6G20BSPk85yN/jS3+0WNkP19ahwO9Nc7L6STel4hujvKii3osf0p0tU2q5Mk2Y8b9f2dVR1ng==",
       "license": "MIT",
       "dependencies": {
         "@iarna/toml": "^3.0.0",
@@ -155,9 +155,9 @@
       }
     },
     "node_modules/filebrowser-startos": {
-      "resolved": "git+ssh://git@github.com/Start9Labs/filebrowser-startos.git#234adec588e4761615be3104d7c3214bd265d522",
+      "resolved": "git+ssh://git@github.com/Start9Labs/filebrowser-startos.git#e1392cbac7e6eb6d55e6efe30207ea6fd622fd2e",
       "dependencies": {
-        "@start9labs/start-sdk": "1.5.1"
+        "@start9labs/start-sdk": "1.5.2"
       }
     },
     "node_modules/ini": {
@@ -195,9 +195,9 @@
       }
     },
     "node_modules/nextcloud-startos": {
-      "resolved": "git+ssh://git@github.com/Start9Labs/nextcloud-startos.git#7f46e0d588d41697b5e14cad4f5fe0450f3256f3",
+      "resolved": "git+ssh://git@github.com/Start9Labs/nextcloud-startos.git#1bd191ce35b7d7d05fa701fee13b95b3e6e49678",
       "dependencies": {
-        "@start9labs/start-sdk": "1.5.1"
+        "@start9labs/start-sdk": "1.5.2"
       }
     },
     "node_modules/node-fetch": {
@@ -356,7 +356,6 @@
       "resolved": "https://registry.npmjs.org/zod/-/zod-4.3.6.tgz",
       "integrity": "sha512-rftlrkhHZOcjDwkGlnUtZZkvaPHCsDATp4pGpuOOMDaTdDDXF91wuVDJoWoPsKX/3YPQ5fHuF3STjcYyKr+Qhg==",
       "license": "MIT",
-      "peer": true,
       "funding": {
         "url": "https://github.com/sponsors/colinhacks"
       }

--- a/package.json
+++ b/package.json
@@ -6,7 +6,7 @@
     "check": "tsc --noEmit"
   },
   "dependencies": {
-    "@start9labs/start-sdk": "1.5.1",
+    "@start9labs/start-sdk": "1.5.2",
     "filebrowser-startos": "github:Start9Labs/filebrowser-startos#next",
     "nextcloud-startos": "github:Start9Labs/nextcloud-startos#next"
   },

--- a/startos/versions/index.ts
+++ b/startos/versions/index.ts
@@ -1,7 +1,7 @@
 import { VersionGraph } from '@start9labs/start-sdk'
-import { v_10_11_8_4 } from './v10.11.8.4'
+import { v_10_11_8_5 } from './v10.11.8.5'
 
 export const versionGraph = VersionGraph.of({
-  current: v_10_11_8_4,
+  current: v_10_11_8_5,
   other: [],
 })

--- a/startos/versions/v10.11.8.5.ts
+++ b/startos/versions/v10.11.8.5.ts
@@ -3,14 +3,14 @@ import { readFile, rm } from 'fs/promises'
 import { configJson, defaultPlugins } from '../fileModels/config.json'
 import { store, type StoreType } from '../fileModels/store.json'
 
-export const v_10_11_8_4 = VersionInfo.of({
-  version: '10.11.8:4',
+export const v_10_11_8_5 = VersionInfo.of({
+  version: '10.11.8:5',
   releaseNotes: {
-    en_US: '**Internal**\n\n- Bump @start9labs/start-sdk to 1.5.0.',
-    es_ES: '**Interno**\n\n- Actualiza @start9labs/start-sdk a 1.5.0.',
-    de_DE: '**Intern**\n\n- @start9labs/start-sdk auf 1.5.0 aktualisiert.',
-    pl_PL: '**Wewnętrzne**\n\n- Aktualizacja @start9labs/start-sdk do 1.5.0.',
-    fr_FR: '**Interne**\n\n- Mise à jour de @start9labs/start-sdk vers 1.5.0.',
+    en_US: 'Bumps @start9labs/start-sdk to 1.5.2.',
+    es_ES: 'Actualiza @start9labs/start-sdk a 1.5.2.',
+    de_DE: 'Aktualisiert @start9labs/start-sdk auf 1.5.2.',
+    pl_PL: 'Aktualizuje @start9labs/start-sdk do 1.5.2.',
+    fr_FR: 'Met à jour @start9labs/start-sdk vers 1.5.2.',
   },
   migrations: {
     up: async ({ effects }) => {


### PR DESCRIPTION
## Summary

- Bumps `@start9labs/start-sdk` from 1.5.1 → 1.5.2 and rolls the StartOS revision to `10.11.8:5`.
- Upstream Jellyfin is unchanged at 10.11.8.

## SDK delta (1.5.1 → 1.5.2)

- **1.5.2** — Fixes `Backups.withPgDump` / `Backups.withMysqlDump` writing 0-byte dumps through the FUSE backup mount. **Not used by this package.**
- **1.5.1** — Fixes `GetActionInputType` inference and `BindOptions.addSsl` typing. **Neither surface is used by this package.**

No code changes were required; the bump is purely transitive. Per the in-place rename convention in `CONTRIBUTING.md`, `startos/versions/v10.11.8.4.ts` was renamed to `v10.11.8.5.ts` with release notes updated to reflect the SDK that ships in this revision.

## Test plan

- [x] `make` builds both `jellyfin_x86_64.s9pk` (473M) and `jellyfin_aarch64.s9pk` (300M) cleanly at `v10.11.8:5` / SDK 1.5.2.