### PR TITLE
chore: bump jellyfin to 10.11.10; 10.11.8:4 → 10.11.10:0

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM jellyfin/jellyfin:10.11.8
+FROM jellyfin/jellyfin:10.11.10
 
 # TODO: revert this workaround once jellyfin/jellyfin#15148 is fixed upstream
 # and the bundled libe_sqlite3.so no longer uses SSE4.1. At that point,

--- a/package-lock.json
+++ b/package-lock.json
@@ -51,9 +51,9 @@
       }
     },
     "node_modules/@nodable/entities": {
-      "version": "2.1.0",
-      "resolved": "https://registry.npmjs.org/@nodable/entities/-/entities-2.1.0.tgz",
-      "integrity": "sha512-nyT7T3nbMyBI/lvr6L5TyWbFJAI9FTgVRakNoBqCD+PmID8DzFrrNdLLtHMwMszOtqZa8PAOV24ZqDnQrhQINA==",
+      "version": "2.1.1",
+      "resolved": "https://registry.npmjs.org/@nodable/entities/-/entities-2.1.1.tgz",
+      "integrity": "sha512-Pig3HxDIoMgjdEH8OCf/dkcTmLFjJRjWuq8jSnklu284/TKOPibSRERmOykiwmyXTtv61mP+44f3GMx0tLAyjg==",
       "funding": [
         {
           "type": "github",
@@ -155,29 +155,9 @@
       }
     },
     "node_modules/filebrowser-startos": {
-      "resolved": "git+ssh://git@github.com/Start9Labs/filebrowser-startos.git#234adec588e4761615be3104d7c3214bd265d522",
+      "resolved": "git+ssh://git@github.com/Start9Labs/filebrowser-startos.git#6a4bfde10ba2df1684be615f64614b2262822cb6",
       "dependencies": {
-        "@start9labs/start-sdk": "1.5.1"
-      }
-    },
-    "node_modules/filebrowser-startos/node_modules/@start9labs/start-sdk": {
-      "version": "1.5.1",
-      "resolved": "https://registry.npmjs.org/@start9labs/start-sdk/-/start-sdk-1.5.1.tgz",
-      "integrity": "sha512-iztLiOCtHuTfUCd2JOWio4OvBk5qFGa0NI+G+ZB/dQ1sWtunYEnzqMcF6N/Ss4L6+7bBOMAMU4VuhyxeZoHyIw==",
-      "license": "MIT",
-      "dependencies": {
-        "@iarna/toml": "^3.0.0",
-        "@noble/curves": "^1.9.7",
-        "@noble/hashes": "^1.8.0",
-        "@types/ini": "^4.1.1",
-        "deep-equality-data-structures": "^2.0.0",
-        "fast-xml-parser": "~5.7.0",
-        "ini": "^5.0.0",
-        "isomorphic-fetch": "^3.0.0",
-        "mime": "^4.1.0",
-        "yaml": "^2.8.3",
-        "zod": "4.3.6",
-        "zod-deep-partial": "^1.2.0"
+        "@start9labs/start-sdk": "1.5.3"
       }
     },
     "node_modules/ini": {
@@ -215,29 +195,9 @@
       }
     },
     "node_modules/nextcloud-startos": {
-      "resolved": "git+ssh://git@github.com/Start9Labs/nextcloud-startos.git#7f46e0d588d41697b5e14cad4f5fe0450f3256f3",
+      "resolved": "git+ssh://git@github.com/Start9Labs/nextcloud-startos.git#dd6272635e8a0a53633a467d307d07eae04178c8",
       "dependencies": {
-        "@start9labs/start-sdk": "1.5.1"
-      }
-    },
-    "node_modules/nextcloud-startos/node_modules/@start9labs/start-sdk": {
-      "version": "1.5.1",
-      "resolved": "https://registry.npmjs.org/@start9labs/start-sdk/-/start-sdk-1.5.1.tgz",
-      "integrity": "sha512-iztLiOCtHuTfUCd2JOWio4OvBk5qFGa0NI+G+ZB/dQ1sWtunYEnzqMcF6N/Ss4L6+7bBOMAMU4VuhyxeZoHyIw==",
-      "license": "MIT",
-      "dependencies": {
-        "@iarna/toml": "^3.0.0",
-        "@noble/curves": "^1.9.7",
-        "@noble/hashes": "^1.8.0",
-        "@types/ini": "^4.1.1",
-        "deep-equality-data-structures": "^2.0.0",
-        "fast-xml-parser": "~5.7.0",
-        "ini": "^5.0.0",
-        "isomorphic-fetch": "^3.0.0",
-        "mime": "^4.1.0",
-        "yaml": "^2.8.3",
-        "zod": "4.3.6",
-        "zod-deep-partial": "^1.2.0"
+        "@start9labs/start-sdk": "1.5.3"
       }
     },
     "node_modules/node-fetch": {
@@ -396,7 +356,6 @@
       "resolved": "https://registry.npmjs.org/zod/-/zod-4.3.6.tgz",
       "integrity": "sha512-rftlrkhHZOcjDwkGlnUtZZkvaPHCsDATp4pGpuOOMDaTdDDXF91wuVDJoWoPsKX/3YPQ5fHuF3STjcYyKr+Qhg==",
       "license": "MIT",
-      "peer": true,
       "funding": {
         "url": "https://github.com/sponsors/colinhacks"
       }

--- a/startos/versions/current.ts
+++ b/startos/versions/current.ts
@@ -3,7 +3,7 @@ import { readFile, rm } from 'fs/promises'
 import { configJson, defaultPlugins } from '../fileModels/config.json'
 import { store, type StoreType } from '../fileModels/store.json'
 
-export const v_10_11_10_0 = VersionInfo.of({
+export const current = VersionInfo.of({
   version: '10.11.10:0',
   releaseNotes: {
     en_US: 'Updates Jellyfin to 10.11.10 (bugfixes and security patches).',

--- a/startos/versions/index.ts
+++ b/startos/versions/index.ts
@@ -1,7 +1,7 @@
 import { VersionGraph } from '@start9labs/start-sdk'
-import { v_10_11_10_0 } from './v10.11.10.0'
+import { current } from './current'
 
 export const versionGraph = VersionGraph.of({
-  current: v_10_11_10_0,
+  current,
   other: [],
 })

--- a/startos/versions/index.ts
+++ b/startos/versions/index.ts
@@ -1,7 +1,7 @@
 import { VersionGraph } from '@start9labs/start-sdk'
-import { v_10_11_8_4 } from './v10.11.8.4'
+import { v_10_11_10_0 } from './v10.11.10.0'
 
 export const versionGraph = VersionGraph.of({
-  current: v_10_11_8_4,
+  current: v_10_11_10_0,
   other: [],
 })

--- a/startos/versions/v10.11.10.0.ts
+++ b/startos/versions/v10.11.10.0.ts
@@ -3,14 +3,18 @@ import { readFile, rm } from 'fs/promises'
 import { configJson, defaultPlugins } from '../fileModels/config.json'
 import { store, type StoreType } from '../fileModels/store.json'
 
-export const v_10_11_8_4 = VersionInfo.of({
-  version: '10.11.8:4',
+export const v_10_11_10_0 = VersionInfo.of({
+  version: '10.11.10:0',
   releaseNotes: {
-    en_US: '**Internal**\n\n- Bump @start9labs/start-sdk to 1.5.0.',
-    es_ES: '**Interno**\n\n- Actualiza @start9labs/start-sdk a 1.5.0.',
-    de_DE: '**Intern**\n\n- @start9labs/start-sdk auf 1.5.0 aktualisiert.',
-    pl_PL: '**Wewnętrzne**\n\n- Aktualizacja @start9labs/start-sdk do 1.5.0.',
-    fr_FR: '**Interne**\n\n- Mise à jour de @start9labs/start-sdk vers 1.5.0.',
+    en_US: 'Updates Jellyfin to 10.11.10 (bugfixes and security patches).',
+    es_ES:
+      'Actualiza Jellyfin a 10.11.10 (correcciones de errores y parches de seguridad).',
+    de_DE:
+      'Aktualisiert Jellyfin auf 10.11.10 (Fehlerbehebungen und Sicherheitspatches).',
+    pl_PL:
+      'Aktualizuje Jellyfin do 10.11.10 (poprawki błędów i łatki bezpieczeństwa).',
+    fr_FR:
+      'Met à jour Jellyfin vers 10.11.10 (corrections de bugs et correctifs de sécurité).',
   },
   migrations: {
     up: async ({ effects }) => {


### PR DESCRIPTION
## Summary

- Bumps the base image `jellyfin/jellyfin` **10.11.8 → 10.11.10** in `Dockerfile` (patch).
- StartOS version **10.11.8:4 → 10.11.10:0** (`startos/versions/v10.11.10.0.ts`, renamed from `v10.11.8.4.ts`; legacy config.yaml migration preserved, `other: []` unchanged).
- `start-sdk` was already at the latest **1.5.3** — no pin change. `npm update` deduped the nested SDK copies in the `filebrowser`/`nextcloud` dev deps from 1.5.1 → 1.5.3.

### What moved upstream

- **10.11.9** — bugfixes (av1_amf rate control, UserManager EFcore fix, HDR10 VPP tonemapping, QSV CPB size).
- **10.11.10** — security fixes (GHSA-f47c-m7gr-q92j, GHSA-jg92-mrxq-vv75, GHSA-wwwm-px48-fpvq) plus stale UserData cache and user-manager collation fixes.

No new actions, volumes, interfaces, or user-visible behavior — `README.md` and `instructions.md` need no changes.

### Workaround status

The `COPY --from=jellyfin/jellyfin:10.10.7 libe_sqlite3.so` SSE4.1 workaround for [jellyfin/jellyfin#15148](https://github.com/jellyfin/jellyfin/issues/15148) is retained — the issue is still **open** upstream.

## Test plan

- [x] `npm run check` (tsc --noEmit) passes.
- [ ] `make` builds the 10.11.10:0 `.s9pk` (verified in review).